### PR TITLE
Turn Delivery#address into separate object, Zaikio::Procurement::Address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Turn `Delivery#address` into a separate `Zaikio::Procurement::Address` object. This
+  change is breaking if you previously depended on this property being a Hash.
+
 ## [0.3.1] - 2021-10-28
-- **Breaking change for Supplier API**: When operating on `Article` or `Variant` one must provide scope 
-  of `substrate` or `plate`. Calling `all` or `find` without scope will raise an `ArgumentError` 
+- **Breaking change for Supplier API**: When operating on `Article` or `Variant` one must provide scope
+  of `substrate` or `plate`. Calling `all` or `find` without scope will raise an `ArgumentError`
 
 ## [0.2.2] - 2021-10-25
 

--- a/lib/zaikio/procurement.rb
+++ b/lib/zaikio/procurement.rb
@@ -6,6 +6,7 @@ require "zaikio/procurement/authorization_middleware"
 
 # Models
 require "zaikio/procurement/base"
+require "zaikio/procurement/address"
 require "zaikio/procurement/article"
 require "zaikio/procurement/variant"
 require "zaikio/procurement/substrate_search"

--- a/lib/zaikio/procurement/address.rb
+++ b/lib/zaikio/procurement/address.rb
@@ -1,0 +1,22 @@
+module Zaikio
+  module Procurement
+    class Address < Base
+      attributes :addition,
+                 :addressable,
+                 :addressee,
+                 :country_code,
+                 :county,
+                 :kind,
+                 :location,
+                 :number,
+                 :state,
+                 :street,
+                 :text,
+                 :town,
+                 :types,
+                 :zip_code,
+                 :created_at,
+                 :updated_at
+    end
+  end
+end

--- a/lib/zaikio/procurement/delivery.rb
+++ b/lib/zaikio/procurement/delivery.rb
@@ -6,11 +6,12 @@ module Zaikio
 
       # Attributes
       attributes :confirmed_delivery_date, :desired_delivery_date, :references,
-                 :address, :order_id, :created_at, :updated_at
+                 :order_id, :created_at, :updated_at
 
       # Associations
-      belongs_to :order,             class_name: "Zaikio::Procurement::Order",
-                                     uri: nil
+      belongs_to :address,           class_name: "Zaikio::Procurement::Address", uri: nil
+      belongs_to :order,             class_name: "Zaikio::Procurement::Order", uri: nil
+
       has_many :delivery_line_items, class_name: "Zaikio::Procurement::DeliveryLineItem",
                                      uri: "deliveries/:delivery_id/delivery_line_items(/:id)"
     end

--- a/test/zaikio/procurement_consumer_test.rb
+++ b/test/zaikio/procurement_consumer_test.rb
@@ -376,11 +376,12 @@ class Zaikio::ProcurementConsumerTest < ActiveSupport::TestCase
     end
   end
 
-  test "fetching a specific delivery" do
+  test "fetching a specific delivery and address" do
     VCR.use_cassette("delivery") do
       Zaikio::Procurement.with_token(token) do
         delivery = Zaikio::Procurement::Delivery.find("46a67d80-ff21-403a-9cb3-5b3a9464ae0f")
         assert_equal "46a67d80-ff21-403a-9cb3-5b3a9464ae0f", delivery.id
+        assert_equal "John Doe", delivery.address.addressee
       end
     end
   end


### PR DESCRIPTION
This is easier for clients to work with without having to traverse a hash object. I came across this via https://github.com/rubocop/rubocop/pull/10217