### PR TITLE
Remove Supplier#create_contract_request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
-## [2.0.1] - 2022-08-04
+### Changed
+- **Removed** `Zaikio::Procurement::Supplier#create_contract_request(...)` in favor of `Zaikio::Procurement::Supplier#contract_requests.create(...)` to get errors in the same way as the ActiveModel::Errors
 ### Added
 - `Zaikio::Procurement::Supplier#create_contract_request(...)` which is closer to the actual API specification
 ### Removed

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Zaikio::Procurement.with_token(token) do
 
   # Create a ContractRequest
   supplier = Zaikio::Procurement::Supplier.find("5fd82941-ba2f-4d0b-971a-7050fbbafcef")
-  supplier.create_contract_request(
+  supplier.contract_requests.create(
     customer_number: "1968353479",
     contact_first_name: "Frank",
     contact_last_name: "Gallikanokus",

--- a/lib/zaikio/procurement/supplier.rb
+++ b/lib/zaikio/procurement/supplier.rb
@@ -10,15 +10,15 @@ module Zaikio
         result.collect { |s| Zaikio::Procurement::Supplier.new(s) }
       end
 
+      # Associations
+      has_many :contract_requests, class_name: "Zaikio::Procurement::ContractRequest",
+                                   uri: "suppliers/:supplier_id/contract_requests(/:id)"
+
       # Attributes
       attributes :slug, :name, :connected, :currency, :customer_number, :prices_updated_at,
                  :additional_pricing_agreements, :article_types, :automatically_accept_contract_requests,
                  :brand_color, :cancelation_policy, :logo_url, :maximum_days_until_delivery,
                  :minimum_days_before_delivery, :supports_split_delivery, :maximum_order_size, :created_at, :updated_at
-
-      def create_contract_request(attributes = {})
-        self.class.request(:post, "#{uri}/contract_requests", contract_request: attributes)&.body&.dig("data")
-      end
     end
   end
 end

--- a/test/zaikio/procurement_consumer_test.rb
+++ b/test/zaikio/procurement_consumer_test.rb
@@ -164,7 +164,7 @@ class Zaikio::ProcurementConsumerTest < ActiveSupport::TestCase
         }
 
         assert_difference "Zaikio::Procurement::ContractRequest.all.count" do
-          supplier.create_contract_request(contract_request_data)
+          supplier.contract_requests.create(contract_request_data)
         end
       end
     end


### PR DESCRIPTION
Remove`Zaikio::Procurement::Supplier#create_contract_request(...)` in favor of `Zaikio::Procurement::Supplier#contract_requests.create(...)` to get errors in the same way as the ActiveModel::Errors
