### PR TITLE
Ensure variant search params are escaped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+- Fixed: Ensure variant search params are escaped
 - Removed article type validation
 
 ## [2.1.3] - 2022-12-02

--- a/lib/zaikio/procurement/variant_search.rb
+++ b/lib/zaikio/procurement/variant_search.rb
@@ -10,26 +10,16 @@ module Zaikio
           raise ArgumentError, "When using additional search parameters, you must pass a hash as an argument."
         end
 
-        @response = Zaikio::Procurement::Base.with(path).get
+        @response = Zaikio::Procurement::Base
+                    .request(:get, "variants", type: @type, query: @query, filters: @filters)&.body&.dig("data")
       end
 
       def results
-        @response.results.collect { |variant| Zaikio::Procurement::Variant.new(variant) }
+        @response["results"].collect { |variant| Zaikio::Procurement::Variant.new(variant) }
       end
 
       def available_filters
-        @response.available_filters
-      end
-
-      private
-
-      def path
-        "variants".tap do |qp|
-          qp << "?type=#{@type}"
-          qp << "&query=#{@query}" if @query
-          qp << "&" if @query && @filters.any?
-          qp << @filters.to_query("filters") if @filters
-        end
+        @response["available_filters"]
       end
     end
   end


### PR DESCRIPTION
solves the following issue:
```
Spyke::InvalidPathError (Missing required variables: TOUCH in variants?
type=sheet_substrate,web_substrate,carbonless_copy_paper,self_adhesive,envelope
&query=EXTRAMATT (TOUCH)&filters%5Bcolor%5D=COLDWHITE&filters%5Benvironmental_certifications%5D=FSC+Mix+Credit&filters%5Bgrain%5D=short&filters%5Bheight%5D=720&filters%5Bsubstrate_weight%5D=300&filters%5Bwidth%5D=1020. 
Mark optional variables with parens eg: (:param)):
```